### PR TITLE
PE-1067: update regex to match new version format and old format

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const githubCommitHistoryURL = `${githubApiUrl}${repository}/commits`;
 
 // Other variables
 const fullDescription = "Production Release for Sprint: " + sprintName;
-const versionStrip = versionNumber.match(/v(\d+\.\d+\.\d+)/);
+const versionStrip = versionNumber.match(/v(\d*.*)/);
 const finalVersionNumber = versionStrip[1];
 const releaseTitle = "im-" + finalVersionNumber;
 const jiraUrlStrip = jiraBaseUrl.match(/https:\/\/(\S*)/);


### PR DESCRIPTION
updated the regex so that it will match both the new version format or the old one.

currently hotfixes get the patch number part truncated